### PR TITLE
Update jquery to version 3.x

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -27695,7 +27695,7 @@ jQuery(document).ready(function() {
 	//initialize lightbox
 	$avada_lightbox.initialize_lightbox();
 });
-;jQuery(window).load(function() {
+;jQuery(window).on('load', function() {
     // Avada dropdown styles
     if ( !Boolean( Number( js_local_vars.avada_styles_dropdowns ) ) ) {
 
@@ -27958,7 +27958,7 @@ recursive_gform_submission_handler();
         });
     }
 );
-;jQuery(window).load(function() {
+;jQuery(window).on('load', function() {
     // BBPress
     jQuery( '.bbp-template-notice' ).each(
         function() {
@@ -28057,7 +28057,7 @@ jQuery(
 );
 
 // Resize crossfade images and square to be the largest image and also vertically centered
-jQuery( window ).load(
+jQuery( window ).on( 'load',
     function() {
         jQuery( window ).resize(
             function() {
@@ -28855,7 +28855,7 @@ jQuery( document ).ready(
 );
 
 // ThemeFusion edit for Avada theme: needed if FusionSlider is present to recalc the dimensions
-jQuery( window ).load( function() {
+jQuery( window ).on( 'load', function() {
 	// setTimeout( parallaxAll, 1 );
 	setTimeout(
 		function() {
@@ -29463,7 +29463,7 @@ jQuery( document ).ready(
     }
 );
 
-jQuery( window ).load(
+jQuery( window ).on( 'load',
 	function() {
         jQuery( '[data-youtube-video-id], [data-vimeo-video-id]' ).each(
             function() {
@@ -30370,7 +30370,7 @@ jQuery( window ).load(
 	}
 });
 
-jQuery( window ).load(function() {
+jQuery( window ).on( 'load',function() {
 	// Sticky Header
 	if( js_local_vars.header_sticky == '1' && ( jQuery( '.fusion-header-wrapper' ).length >= 1 || jQuery( '#side-header').length >= 1 ) ) {
 		var $animation_duration = 300;
@@ -32012,7 +32012,7 @@ function fusion_side_header_scroll() {
 
 })( jQuery );
 
-jQuery( window ).load( function() { // start window_load_1
+jQuery( window ).on( 'load', function() { // start window_load_1
 
 	// Static layout
 	if( js_local_vars.is_responsive == '0' ) {
@@ -33531,7 +33531,7 @@ jQuery( document ).ready(function($) { // start document_ready_1
 	});
 }); // end document_ready_1
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
     if(cssua.ua.mobile === undefined) {
 	    // Change opacity of page title bar on scrolling
 	    if(js_local_vars.page_title_fading == '1') {
@@ -33635,7 +33635,7 @@ jQuery(document).ready(function() {
 	jQuery('#bbpress-forums').fitVids();
 });
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
 	jQuery('.fusion-youtube-flash-fix').remove();
 });
 
@@ -33701,7 +33701,7 @@ if ( ! orig_logo_container_margin_bottom ) {
 	orig_logo_container_margin_bottom = '0px';
 }
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
 	var headerHeight = jQuery( '.fusion-header-wrapper' ).height();
 
 	if(jQuery('.sidebar').is(':visible')) {
@@ -35405,7 +35405,7 @@ jQuery( document ).ready( function() {
 	}
 });
 
-jQuery( window ).load( function() {
+jQuery( window ).on( 'load', function() {
 	if ( jQuery( '.fusion-secondary-menu .fusion-secondary-menu-cart' ).width() > 176 ) {
 		setTimeout( function() {
 			var cart_width = jQuery( '.fusion-secondary-menu .fusion-secondary-menu-cart' ).outerWidth(),
@@ -35970,7 +35970,7 @@ if ( location.hash ) {
 	jQuery('body').append( $one_page_link );
 
 	// Scroll the page
-	jQuery( window ).load( function() {
+	jQuery( window ).on( 'load', function() {
 		setTimeout( function() {
 			$one_page_link.trigger( 'click' );
 		}, 100);

--- a/js/theme.js
+++ b/js/theme.js
@@ -1000,7 +1000,7 @@ function fusion_side_header_scroll() {
 
 })( jQuery );
 
-jQuery( window ).load( function() { // start window_load_1
+jQuery( window ).on( 'load', function() { // start window_load_1
 
 	// Static layout
 	if( js_local_vars.is_responsive == '0' ) {
@@ -1154,11 +1154,11 @@ jQuery( window ).load( function() { // start window_load_1
 		jQuery( '#wrapper' ).append( jQuery( this ) );
 	});
 
-	jQuery( '.fusion-modal' ).bind('hidden.bs.modal', function () {
+	jQuery( '.fusion-modal' ).on('hidden.bs.modal', function () {
 		jQuery( 'html' ).css( 'overflow', '' );
 	});
 
-	jQuery( '.fusion-modal' ).bind('show.bs.modal', function () {
+	jQuery( '.fusion-modal' ).on('show.bs.modal', function () {
 		var $slidingbar = jQuery( '#slidingbar' );
 
 		jQuery( 'html' ).css( 'overflow', 'visible' );
@@ -2343,7 +2343,7 @@ jQuery( document ).ready(function($) { // start document_ready_1
 		jQuery( this ).addClass( 'products-' + js_local_vars.woocommerce_shop_page_columns );
 	});
 
-	jQuery('.woocommerce-tabs ul.tabs li a').unbind( 'click' );
+	jQuery('.woocommerce-tabs ul.tabs li a').off( 'click' );
 	jQuery('.woocommerce-tabs > ul.tabs li a').click(function(){
 
 		var tab = jQuery( this );
@@ -2519,7 +2519,7 @@ jQuery( document ).ready(function($) { // start document_ready_1
 	});
 }); // end document_ready_1
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
     if(cssua.ua.mobile === undefined) {
 	    // Change opacity of page title bar on scrolling
 	    if(js_local_vars.page_title_fading == '1') {
@@ -2623,7 +2623,7 @@ jQuery(document).ready(function() {
 	jQuery('#bbpress-forums').fitVids();
 });
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
 	jQuery('.fusion-youtube-flash-fix').remove();
 });
 
@@ -2689,7 +2689,7 @@ if ( ! orig_logo_container_margin_bottom ) {
 	orig_logo_container_margin_bottom = '0px';
 }
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
 	var headerHeight = jQuery( '.fusion-header-wrapper' ).height();
 
 	if(jQuery('.sidebar').is(':visible')) {
@@ -4393,7 +4393,7 @@ jQuery( document ).ready( function() {
 	}
 });
 
-jQuery( window ).load( function() {
+jQuery( window ).on( 'load', function() {
 	if ( jQuery( '.fusion-secondary-menu .fusion-secondary-menu-cart' ).width() > 176 ) {
 		setTimeout( function() {
 			var cart_width = jQuery( '.fusion-secondary-menu .fusion-secondary-menu-cart' ).outerWidth(),
@@ -4559,7 +4559,7 @@ jQuery( window ).load( function() {
 				}, 10 );
 
 				// Reset the click event for the collapse-month toggle
-				jQuery( $blog_infinite_container ).find( '.fusion-timeline-date' ).unbind( 'click' );
+				jQuery( $blog_infinite_container ).find( '.fusion-timeline-date' ).off( 'click' );
 				jQuery( $blog_infinite_container ).find( '.fusion-timeline-date' ).click( function() {
 					jQuery( this ).next( '.fusion-collapse-month' ).slideToggle();
 				});
@@ -4958,7 +4958,7 @@ if ( location.hash ) {
 	jQuery('body').append( $one_page_link );
 
 	// Scroll the page
-	jQuery( window ).load( function() {
+	jQuery( window ).on( 'load', function() {
 		setTimeout( function() {
 			$one_page_link.trigger( 'click' );
 		}, 100);


### PR DESCRIPTION
Update jQuery code for compatibility with jQuery 3.x.

This PR replaces deprecated jQuery methods (`.load()`, `.bind()`, `.unbind()`) with their modern equivalents (`.on('load', ...)`, `.on()`, `.off()`) to ensure full compatibility with jQuery 3.x.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd264215-4125-41ae-933c-e3ed08e1bedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd264215-4125-41ae-933c-e3ed08e1bedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

